### PR TITLE
synthdef names for clean_crush & clean_coarse were changed to  bit & …sam, but ~clean.addModule was still calling them by the old names

### DIFF
--- a/synths/core-modules.scd
+++ b/synths/core-modules.scd
@@ -106,7 +106,7 @@ they respond to the existence of a value for one of the parameters
 
 ~clean.addModule(\bit,
 	{ |cleanEvent|
-		cleanEvent.sendSynth(\clean_crush ++ ~numChannels,
+		cleanEvent.sendSynth(\bit ++ ~numChannels,
 			[
 				crush: ~bit,
 				out: ~out
@@ -117,7 +117,7 @@ they respond to the existence of a value for one of the parameters
 
 ~clean.addModule(\sam,
 	{ |cleanEvent|
-		cleanEvent.sendSynth(\clean_coarse ++ ~numChannels,
+		cleanEvent.sendSynth(\sam ++ ~numChannels,
 			[
 				coarse: ~sam,
 				out: ~out


### PR DESCRIPTION
Hi Daniel, 

Separate from the stuff I've been working on, I noticed a bug this evening:
The SynthDef names for \clean_crush & \clean_coarse were changed to \bit and \sam, however in the ~clean.addModule event entry, they were still being referred to by their long names, and thus not working. 

I updated the name they're referred to in the Event - seemed like the simplest solution for the time being...

Boris