### PR TITLE
CleanEvent.sc: fixed event legato behavior

### DIFF
--- a/classes/CleanEvent.sc
+++ b/classes/CleanEvent.sc
@@ -41,7 +41,52 @@ CleanEvent {
 			if(~diversion.isNil) { ~notFound.value }
 		} {
 			// the stored sound event becomes the environment's proto slot, which partly can override its parent
-			currentEnvironment.proto = soundEvent
+			currentEnvironment.proto = soundEvent;
+
+
+			// legato/sustain/release overlap fix:
+
+			// synth's envelope release time cut along with event if legato < 1
+			~legato = if(~legato ?? { 1 } >= 1) {
+				~legato ?? { 1 } + (~dur ?? { 1 } * (~rel ?? {
+					if(~clean.soundLibrary.synthEvents[~snd].notNil) {
+						if(SynthDescLib.global.at(~clean.soundLibrary.synthEvents[~snd][0].[\instrument]).controlDict[\release].notNil) {
+							SynthDescLib.global.at(~clean.soundLibrary.synthEvents[~snd][0].[\instrument]).controlDict[\release].defaultValue
+						} {
+							if(SynthDescLib.global.at(~clean.soundLibrary.synthEvents[~snd][0].[\instrument]).controlDict[\rel].notNil) {
+								SynthDescLib.global.at(~clean.soundLibrary.synthEvents[~snd][0].[\instrument]).controlDict[\rel].defaultValue
+						} { 1 } }
+					} { if(SynthDescLib.global.at(~snd).notNil) {
+						if(SynthDescLib.global.at(~snd).controlDict[\release].notNil) {
+							SynthDescLib.global.at(~snd).controlDict[\release].defaultValue
+						} {
+							if(SynthDescLib.global.at(~snd).controlDict[\rel].notNil) {
+								SynthDescLib.global.at(~snd).controlDict[\rel].defaultValue
+						} {	1 } }
+				} { 1 } } }))
+			} {
+				~legato
+			}
+
+			// synth's envelope release time persists (still happens) even if legato < 1
+			/*
+			~legato =  ~legato ?? { 1 } + (~dur ?? { 1 } * (~rel ?? {
+				if(~clean.soundLibrary.synthEvents[~snd].notNil) {
+					if(SynthDescLib.global.at(~clean.soundLibrary.synthEvents[~snd][0].[\instrument]).controlDict[\release].notNil) {
+						SynthDescLib.global.at(~clean.soundLibrary.synthEvents[~snd][0].[\instrument]).controlDict[\release].defaultValue
+					} {
+						if(SynthDescLib.global.at(~clean.soundLibrary.synthEvents[~snd][0].[\instrument]).controlDict[\rel].notNil) {
+							SynthDescLib.global.at(~clean.soundLibrary.synthEvents[~snd][0].[\instrument]).controlDict[\rel].defaultValue
+					} { 1 } }
+				} { if(SynthDescLib.global.at(~snd).notNil) {
+					if(SynthDescLib.global.at(~snd).controlDict[\release].notNil) {
+						SynthDescLib.global.at(~snd).controlDict[\release].defaultValue
+					} {
+						if(SynthDescLib.global.at(~snd).controlDict[\rel].notNil) {
+							SynthDescLib.global.at(~snd).controlDict[\rel].defaultValue
+					} {	1 } }
+			} { 1 } } }))
+			*/
 		}
 	}
 


### PR DESCRIPTION
Modified mergeSoundEvent so that legato does not cause the event to free all synths before release times have ended.

Legato is now calculated as: legato = legato + (dur * rel)

This functionality also works even if legato, dur, or rel are not explicitly stated by provided the default values for each key. Release time is looked up in the SynthDescLib by matching snd's key value to either an SynthDef name entry in  ~clean.soundLibrary or directly in SynthDescLib. If no default release time is found, 1 second is then the release time.

 If legato, dur, or rel are explicitly stated in a pattern, then that key's value will be used in place of the default, as is the expected behavior.