### PR TITLE
Removing amp methods from CleanAux seems to fix amp multichannel expansion

### DIFF
--- a/classes/CleanAux.sc
+++ b/classes/CleanAux.sc
@@ -116,22 +116,6 @@ CleanAux {
 		globalEffects.do { |x| x.set(event) };
 	}
 
-	amp_ { |val|
-		this.set(\amp, val)
-	}
-
-	amp {
-		^this.get(\amp)
-	}
-
-	fadeTime_ { |val|
-		this.set(\fadeTime, val)
-	}
-
-	fadeTime {
-		^this.get(\fadeTime)
-	}
-
 	freeSynths {
 		server.bind {
 			server.sendMsg("/n_free", group);
@@ -178,7 +162,7 @@ CleanAux {
 			~end = 1.0;
 			~spd = 1.0;
 			~pan = 0.5;
-			~amp = 0.75;
+			~amp = 0.5;
 			~cut = 0.0;
 			~sac = 0.99;
 			~slo = 1.0;
@@ -188,7 +172,7 @@ CleanAux {
 			~hit = 0.0;
 			~nhp = 20;
 			~nlp = 20000;
-			//~mii = 1;
+			~mii = 1;
 			~unit = \r;
 			~midinote = #{ ~note ? ~num + (~octave * 12) };
 			~freq = #{
@@ -244,7 +228,6 @@ CleanAux {
 			~lop = 1.0;
 			~dry = 0.0;
 			~lock = 0; // if set to 1, syncs delay times with cps
-			~amp = 0.5;
 			~fadeTime = 0.001;
 
 			// values from the clean bus

--- a/classes/CleanEvent.sc
+++ b/classes/CleanEvent.sc
@@ -165,7 +165,6 @@ CleanEvent {
 	}
 
 	finaliseParameters {
-		~amp = pow(~amp.value, 1) * ~amp.value;
 		~channel !? { ~pan = ~pan.value + (~channel.value / ~numChannels) };
 		~pan = ~pan * 2 - 1; // convert unipolar (0..1) range into bipolar one (-1...1)
 		~delayAmp = ~dla ? 0.0; // below is how you would rename parameter names to anything you want


### PR DESCRIPTION
Also note that I removed the amp scaling from CleanEvent's finaliseParameters. It provided a strange curve to amp. 

The result of this change is that low value amp settings should now be louder. 

I personally think that type of scaling should be handled by the user, but I'm happy to put it back in if you want, Daniel. 