### PR TITLE
rma and flp modules only when needed

### DIFF
--- a/synths/core-synths-global.scd
+++ b/synths/core-synths-global.scd
@@ -150,7 +150,7 @@ They'll come back automatically.
 
 	// NHHall based reverb
 	SynthDef(\clean_hal ++ numChannels, {
-		|dryBus, effectBus, gate=1, hal, hai = 1, hhp=20, hlp=20000, rts=1, bld=0.5, edf=0.5, ldf=0.5|
+		|dryBus, effectBus, gate=1, hal = 0, hai = 1, hhp=20, hlp=20000, rts=1, bld=0.5, edf=0.5, ldf=0.5|
 		var lgt = 0.0625;
 		var signal = In.ar(dryBus, numChannels);
 		signal = signal * hai.lag(lgt);
@@ -162,7 +162,7 @@ They'll come back automatically.
 		};
 		signal = signal * EnvGen.kr(Env.asr, gate, doneAction:2);
 		signal = LeakDC.ar(signal);
-		signal = signal * (1 - hal -1).lag(lgt);
+		signal = signal * hal.lag(lgt);
 		CleanPause.ar(signal.sum, graceTime:4);
 		Out.ar(effectBus, signal);
 	}, [\ir, \ir]).add;

--- a/synths/core-synths-global.scd
+++ b/synths/core-synths-global.scd
@@ -40,7 +40,7 @@ They'll come back automatically.
 	}, [\ir, \ir, \kr, \kr]).add;
 
 	// RMS measurement, sending back to editor
-	SynthDef(\clean_rms ++ numChannels, { |gate = 1, dryBus, effectBus, rmsReplyRate, rmsPeakLag, auxIndex|
+	SynthDef(\clean_rms ++ numChannels, { |gate = 1, dryBus, effectBus, rmsReplyRate = 20, rmsPeakLag = 3, auxIndex|
 		var drySignal = In.ar(dryBus, numChannels);
 		var wetSignal = In.ar(effectBus, numChannels);
 		var signal = wetSignal + drySignal;

--- a/synths/core-synths-global.scd
+++ b/synths/core-synths-global.scd
@@ -102,7 +102,7 @@ They'll come back automatically.
 		var in, snd, loop, depth;
 		in = In.ar(dryBus, numChannels).asArray.sum;
 		in = in * rin.lag(LFNoise1.kr(1).range(0.01, 0.02)); // regulate input
-		4.do { in = AllpassN.ar(in, 0.03, { Rand(0.005, 0.02) }.dup(numChannels), 1) };
+		4.do { in = AllpassN.ar(in, 0.02, { Rand(0.005, 0.02) }.dup(numChannels), 1) };
 		depth = rev.lag(0.02).linexp(0, 1, 0.01, 0.98); // change depth between 0.1 and 0.98
 		loop = LocalIn.ar(numChannels) * { depth + Rand(0, 0.05) }.dup(numChannels);
 		loop = OnePole.ar(loop, 0.5);  // 0-1
@@ -127,7 +127,7 @@ They'll come back automatically.
 		sig = GVerb.ar(
 			sig * cai.clip(0.0, 1.0).lag(lgt),
 			250,
-			cvt.clip(0.0, 1.0).linlin(0.0, 1.0, 0.001, 30).lag(lgt),
+			cvt.linlin(0.0, 1.0, 0.001, 30).lag(lgt),
 			cvd.clip(0.0, 1.0).lag(lgt), 0.5, 15, 1, 0.7, 0.5);
 		sig = LPF.ar(sig, cvl.clip(0.0, 1.0).lag(lgt).linexp(0.0, 1.0, 20.0, 1000.0));
 		sig = sig * (1 - cav.lag(lgt) - 1);
@@ -151,7 +151,7 @@ They'll come back automatically.
 	// NHHall based reverb
 	SynthDef(\clean_hal ++ numChannels, {
 		|dryBus, effectBus, gate=1, hal, hai = 1, hhp=20, hlp=20000, rts=1, bld=0.5, edf=0.5, ldf=0.5|
-		var wet, lgt = 0.0625;
+		var lgt = 0.0625;
 		var signal = In.ar(dryBus, numChannels);
 		signal = signal * hai.lag(lgt);
 		signal = HPF.ar(signal, hhp.clip(20,20000).lag(lgt));
@@ -179,7 +179,7 @@ They'll come back automatically.
 		sig = sig = tanh(sig);
 		sig = LPF.ar(sig, tna.clip(20, 20000).lag(lgt));
 		sig = LeakDC.ar(sig);
-		sig = sig * (1 - tnh.linlin(0.0, 1.0, 1.0, 0.0));
+		sig = sig * tnh;
 		CleanPause.ar(sig, graceTime:4);
 		sig = sig * EnvGen.kr(Env.asr, gate, doneAction:2);
 		Out.ar(effectBus, sig);
@@ -193,7 +193,7 @@ They'll come back automatically.
 		var lgt = 0.0625;
 		sig = sig = DFM1.ar(sig, dff.clip(20, 20000).lag(12), 0.0, dfg.clip(0.0, 999.0).lag(0.1), 0.0, 0.0);
 		//sig = LeakDC.ar(sig);
-		sig = sig * (1 - dfm.linlin(0.0, 1.0, 1.0, 0.0));
+		sig = sig * dfm;
 		CleanPause.ar(sig, graceTime:4);
 		sig = sig * EnvGen.kr(Env.asr, gate, doneAction:2);
 		Out.ar(effectBus, sig);
@@ -205,7 +205,7 @@ They'll come back automatically.
 		var wetSignal = In.ar(effectBus, numChannels);
 		var sig = wetSignal + drySignal;
 		var lgt = 0.5;
-		var trem = trd.clip(0.0, 1.0).linlin(0.0, 1.0, 0.0, 2.0).lag(lgt) * SinOsc.kr(trr.clip(0, 999).lag(lgt) + LFNoise1.kr(tvr.clip(0, 99).linlin(0.0, 99.0, 0.0, 999.0).lag(lgt), tvd.clip(0, 999).lag(lgt)));
+		var trem = trd.linlin(0.0, 1.0, 0.0, 2.0).lag(lgt) * SinOsc.kr(trr.clip(0, 999).lag(lgt) + LFNoise1.kr(tvr.linlin(0.0, 99.0, 0.0, 999.0).lag(lgt), tvd.clip(0, 999).lag(lgt)));
 		var mix = 1 + trem;
 		sig = sig * mix;
 		sig = sig;
@@ -222,7 +222,7 @@ They'll come back automatically.
 		sig = In.ar(dryBus, numChannels).asArray.sum;
 		sig = sig * jpg.clip(0.0, 999.0);
 		sig = sig = tanh(sig);
-		sig = JPverb.ar(sig, jts.clip(0.0, 1.0).linlin(0.0, 1.0, 0.1, 60.0).lag.(lgt), jpd.clip(0.0, 1.0).lag.(lgt), jps.clip(0.0, 1.0).linlin(0.0, 1.0, 0.5, 5.0).lag.(lgt), jed.clip(0.0, 1.0).linlin(0.0,
+		sig = JPverb.ar(sig, jts.linlin(0.0, 1.0, 0.1, 60.0).lag.(lgt), jpd.clip(0.0, 1.0).lag.(lgt), jps.linlin(0.0, 1.0, 0.5, 5.0).lag.(lgt), jed.linlin(0.0,
             1.0, 0.8, 1.0).lag.(lgt), jmd.clip(0.0, 1.0).lag.(lgt), jmf.clip(0.0, 1.0).lag.(lgt), jpl.clip(0.0, 1.0).lag.(lgt), jpm.clip(0.0, 1.0).lag.(lgt), jph.clip(0.0, 1.0).lag.(lgt), jlc.clip(0.0, 1.0).linexp(0.0, 1.0, 100.0,
                 6000.0).lag.(lgt), jhc.clip(0.0, 1.0).linexp(0.0, 1.0, 1000.0, 10000.0).lag.(lgt));
 		sig = sig * jpr;

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -635,14 +635,10 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 
 		}, { ~flp.notNil and: { ~flp >= 0.5 } });
 
-		SynthDef(\clean_channel_flip ++ numChannels, { |out=0, in=0 flp=0|
-			var sig = In.ar(out, numChannels);
-			sig = Select.ar(flp, [
-				sig,
-				sig.reverse
-			]);
+		SynthDef(\clean_channel_flip ++ numChannels, { |out=0|
+			var sig = In.ar(out, numChannels).reverse;
 			ReplaceOut.ar(out, sig)
-		}, [\ir, \ir]).add;
+		}, #[\ir]).add;
 
 
 	~clean.addModule(\brf,

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -486,9 +486,8 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 	}, { ~hbrick.notNil });
 
 	SynthDef('spectral-hbrick' ++ ~clean.numChannels, { |out, hbrick|
-		var signal, chain, in, clean, teeth = 256;
+		var signal, chain;
 		signal = In.ar(out, ~clean.numChannels);
-		clean = signal;
 		chain = signal.asArray.collect { |x| FFT(LocalBuf(2048), x) };
 		signal = IFFT(PV_BrickWall(chain, wipe: hbrick * 0.6)); // Signal almost disappears around 0.5 therefore it's scaled a bit
 		ReplaceOut.ar(out, signal)
@@ -505,9 +504,8 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 	}, { ~lbrick.notNil });
 
 	SynthDef('spectral-lbrick' ++ ~clean.numChannels, { |out, lbrick|
-		var signal, chain, in, clean, teeth = 256;
+		var signal, chain;
 		signal = In.ar(out, ~clean.numChannels);
-		clean = signal;
 		chain = signal.asArray.collect { |x| FFT(LocalBuf(2048), x) };
 		// lbrick parameter scaled to negative range to activate lopass filter (see ugen help file)
 		signal = IFFT(PV_BrickWall(chain, wipe: lbrick.linlin(0.0,1.0,0.0,(-1.0))));
@@ -526,9 +524,8 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 	}, { ~ral.notNil or: ~img.notNil });
 
 	SynthDef('spectral-conformer' ++ ~clean.numChannels, { |out, real = 0.5, imag = 0.5|
-		var signal, chain, in, clean, teeth = 256;
+		var signal, chain;
 		signal = In.ar(out, ~clean.numChannels);
-		clean = signal;
 		chain = signal.asArray.collect { |x| FFT(LocalBuf(2048), x) };
 		signal = IFFT(
 			PV_ConformalMap(chain, real.linlin(0.0,1.0,0.01,2.0), imag.linlin(0.00,1.0,0.01,10.0))
@@ -547,9 +544,8 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 	}, { ~enh.notNil });
 
 	SynthDef('spectral-enhance' ++ ~clean.numChannels, { |out, enhance = 0.5|
-		var signal, chain, in, clean, teeth = 256;
+		var signal, chain;
 		signal = In.ar(out, ~clean.numChannels);
-		clean = signal;
 		chain = signal.asArray.collect { |x| FFT(LocalBuf(2048), x) };
 		signal = IFFT(
 			PV_SpectralEnhance(chain,

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -325,7 +325,7 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 				out: ~out
 			]
 		)
-	}, { ~rma.notNil });
+	}, { ~rma.notNil and: { ~rma != 0.0 and: { ~rmf != 0.0 and: { ~rdf != 0.0 } } } });
 
 	SynthDef(\clean_rma ++ ~clean.numChannels, { |out, rma = 0, rmf = 0, rdf, rdt = 0.5|
 		var signal, mod;
@@ -633,7 +633,7 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 						out: ~out
 				])
 
-		}, { ~flp.notNil });
+		}, { ~flp.notNil and: { ~flp >= 0.5 } });
 
 		SynthDef(\clean_channel_flip ++ numChannels, { |out=0, in=0 flp=0|
 			var sig = In.ar(out, numChannels);

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -17,14 +17,14 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 
 		SynthDef(name, { |out, bufnum, sustain = 1, bgn = 0, spd = 1, endspd = 1, freq = 440, pan = 0|
 
-			var sound, rate, phase;
+			var sound, rate, offset;
 
 			// Playback speed.
 			rate = Line.kr(spd, endspd, sustain) * (freq / 60.midicps);
 
-			// Sample phase.
+			// Start position.
 			// BufSampleRate adjusts the rate if the sound file doesn't have the same rate as the soundcard.
-			phase =  Sweep.ar(1, rate * BufSampleRate.ir(bufnum)) + (BufFrames.ir(bufnum) * bgn);
+			offset = BufFrames.ir(bufnum) * bgn;
 
 			/*
 			sound = BufRd.ar(
@@ -35,7 +35,7 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 			interpolation: 4
 			);
 			*/
-			sound = PlayBuf.ar(sampleNumChannels, bufnum, BufRateScale.ir(bufnum) * rate, startPos: phase, loop: 0.0, doneAction:0);
+			sound = PlayBuf.ar(sampleNumChannels, bufnum, BufRateScale.ir(bufnum) * rate, startPos: offset, loop: 0.0, doneAction:0);
 			sound = CleanPan.ar(sound, numChannels, pan);
 
 			Out.ar(out, sound)

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -166,7 +166,7 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 	SynthDef(\clean_bpf ++ numChannels, { |out, bandqf = 440, bandq = 10|
 		var signal = In.ar(out, numChannels);
 		//bandq = max(1, bandq); // limit quality, avoid division by zero
-		bandq = bandq.clip(0, 1).linlin(0, 1, 1, 10000);
+		bandq = bandq.linlin(0, 1, 1, 10000);
 		bandqf = max(20, bandqf); // limit lower end, avoid blow up
 		bandqf = bandqf.abs.clip(20, 20000);
 
@@ -369,7 +369,7 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 
 	SynthDef('spectral-delay' ++ ~clean.numChannels, { |out, tsdelay = 0.5, xsdelay = 0.5, sda = 0, sdq = 0.005|
 
-		var signal, delayTime, delays, freqs, filtered;
+		var signal, delayTime, filtered;
 		var size = 16;
 		var maxDelayTime = 0.2;
 		signal = In.ar(out, ~clean.numChannels);
@@ -413,7 +413,7 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 	}, { ~cmb.notNil });
 
 	SynthDef('spectral-comb' ++ ~clean.numChannels, { |out, comb|
-		var signal, chain, in, clean, teeth = 256;
+		var signal, chain, teeth = 256;
 		signal = In.ar(out, ~clean.numChannels);
 		chain = signal.asArray.collect { |x| FFT(LocalBuf(2048), x) };
 		signal = IFFT(PV_RectComb(chain, numTeeth: teeth * comb.abs.clip(0.0, 1.0), width: 1-comb.abs.clip(0.0, 1.0)));
@@ -431,7 +431,7 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 	}, { ~smr.notNil });
 
 	SynthDef('spectral-smear' ++ ~clean.numChannels, { |out, smear|
-		var signal, chain, in;
+		var signal, chain;
 		signal = In.ar(out, ~clean.numChannels);
 		chain = signal.asArray.collect { |x| FFT(LocalBuf(2048), x) };
 		signal = IFFT(PV_MagSmear(chain, bins: smear.linexp(0.0,1.0,1,64)));
@@ -449,9 +449,8 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 	}, { ~scm.notNil });
 
 	SynthDef('spectral-scram' ++ ~clean.numChannels, { |out, scram|
-		var signal, chain, in, clean, teeth = 256;
+		var signal, chain;
 		signal = In.ar(out, ~clean.numChannels);
-		clean = signal;
 		chain = signal.asArray.collect { |x| FFT(LocalBuf(2048), x) };
 		signal = IFFT(PV_BinScramble(chain, wipe: scram, width: scram));
 		ReplaceOut.ar(out, signal)
@@ -468,9 +467,8 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 	}, { ~sbs.notNil });
 
 	SynthDef('spectral-binshift' ++ ~clean.numChannels, { |out, binshift|
-		var signal, chain, in, clean, teeth = 256;
+		var signal, chain;
 		signal = In.ar(out, ~clean.numChannels);
-		clean = signal;
 		chain = signal.asArray.collect { |x| FFT(LocalBuf(2048), x) };
 		signal = IFFT(PV_BinShift(chain, stretch: binshift.linlin(0.0,1.0,0.01,4.0),
 			shift: binshift * 10, interp: 1));

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -17,17 +17,19 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 
 		SynthDef(name, { |out, bufnum, sustain = 1, bgn = 0, end = 1, spd = 1, endspd = 1, freq = 440, pan = 0|
 
-			var sound, rate, phase, sawrate, numFrames;
+			var sound, rate, phase, sawrate, numFrames, sweeprate;
 
 			// Playback speed.
 			rate = Line.kr(spd, endspd, sustain) * (freq / 60.midicps);
 
+			numFrames = BufFrames.ir(bufnum);
+			sweeprate = rate * BufSampleRate.ir(bufnum);
+
 			// Sample phase.
 			// BufSampleRate adjusts the rate if the sound file doesn't have the same rate as the soundcard.
-			phase =  Sweep.ar(1, rate * BufSampleRate.ir(bufnum)) + (BufFrames.ir(bufnum) * bgn);
+			phase =  Sweep.ar(1, sweeprate) + (numFrames * bgn);
 
-			numFrames = BufFrames.ir(bufnum);
-			sawrate = rate * BufSampleRate.ir(bufnum) / (absdif(bgn, end) * numFrames);
+			sawrate = sweeprate / (absdif(bgn, end) * numFrames);
 			/*
 			sound = BufRd.ar(
 			numChannels: sampleNumChannels,
@@ -41,7 +43,7 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 			sound = CleanPan.ar(sound, numChannels, pan);
 
 			Out.ar(out, sound)
-		}, [\ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir]).add;
+		}, #[\ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir]).add;
 	};
 
 	/*

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -244,9 +244,9 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 
 	SynthDef(\clean_envelope ++ numChannels, { |out, attack = 0, hold = 0, release = inf, crv = 0.3, crt = 0.3|
 		var signal = In.ar(out, numChannels);
-		signal = signal * EnvGen.ar(Env.linen(attack, hold, release, 1, [crv, 0, crt]));
+		signal = signal * EnvGen.ar(Env.linen(attack, hold, release, 1, [crv, 0, crt]), doneAction: 14);
 		ReplaceOut.ar(out, signal);
-	}, [\ir, \ir, \ir, \ir]).add;
+	}, #[\ir, \ir, \ir, \ir, \ir, \ir]).add;
 
 	// Frequency shifter
 	// Total shift is sum of `fshift` (in Hz) and `fshiftnote` times the current note frequency.

--- a/synths/core-synths.scd
+++ b/synths/core-synths.scd
@@ -15,21 +15,17 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 
 		var name = format("clean_sample_%_%", sampleNumChannels, numChannels);
 
-		SynthDef(name, { |out, bufnum, sustain = 1, bgn = 0, end = 1, spd = 1, endspd = 1, freq = 440, pan = 0|
+		SynthDef(name, { |out, bufnum, sustain = 1, bgn = 0, spd = 1, endspd = 1, freq = 440, pan = 0|
 
-			var sound, rate, phase, sawrate, numFrames, sweeprate;
+			var sound, rate, phase;
 
 			// Playback speed.
 			rate = Line.kr(spd, endspd, sustain) * (freq / 60.midicps);
 
-			numFrames = BufFrames.ir(bufnum);
-			sweeprate = rate * BufSampleRate.ir(bufnum);
-
 			// Sample phase.
 			// BufSampleRate adjusts the rate if the sound file doesn't have the same rate as the soundcard.
-			phase =  Sweep.ar(1, sweeprate) + (numFrames * bgn);
+			phase =  Sweep.ar(1, rate * BufSampleRate.ir(bufnum)) + (BufFrames.ir(bufnum) * bgn);
 
-			sawrate = sweeprate / (absdif(bgn, end) * numFrames);
 			/*
 			sound = BufRd.ar(
 			numChannels: sampleNumChannels,
@@ -43,7 +39,7 @@ the SynthDefs, but alas they do not. Default values for parameters get set in Cl
 			sound = CleanPan.ar(sound, numChannels, pan);
 
 			Out.ar(out, sound)
-		}, #[\ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir]).add;
+		}, #[\ir, \ir, \ir, \ir, \ir, \ir, \ir, \ir]).add;
 	};
 
 	/*


### PR DESCRIPTION
before this fix the flip and ring modules were always present.  unnecessary CPU cost.
this fix also blocks a potential NaN in rma (modulator XLine). NaN happens there when rmf and/or rdf are 0.0 (i.e. the default values).

i'd suggest rmf and rdf get resonable default values.  with default values one can turn on ring modulation without needing to explicitly set rmf and rdf like this...
```
(
Pdef(0,
	Pbind(*[
		type: \cln,
		snd: \mmd,
		num: 2,
		dur: 3,
		rma: 1,
		rmf: 100,
		rdf: 200,
	])
).play
)
```