### PR TITLE
do not crash when proto found

### DIFF
--- a/classes/CleanEvent.sc
+++ b/classes/CleanEvent.sc
@@ -234,7 +234,7 @@ CleanEvent {
 			~hash ?? { ~hash = ~snd.identityHash }; // just to be safe
 		};
 
-		if(currentEnvironment.proto[\disk].notNil, {
+		if(currentEnvironment.proto.notNil and:{currentEnvironment.proto[\disk].notNil}, {
 			cuedBuffer = Buffer.cueSoundFile(
 				server,
 				currentEnvironment.proto.path,


### PR DESCRIPTION
safety for when typo in \snd key.