### PR TITLE
Make pattern fade times work: honor fadeTime/fadeInTime, fix Pdef crossfade crash

### DIFF
--- a/classes/CleanAux.sc
+++ b/classes/CleanAux.sc
@@ -272,6 +272,13 @@ CleanAux {
 			~dry = 0.0;
 			~lock = 0; // if set to 1, syncs delay times with cps
 			~amp = 0.5;
+			// mirror of ~amp in decibels. SC's default parent event defines
+			// \amp as #{ ~db.dbamp }; patterns that scale \amp per event
+			// (e.g. Pdef fadeTime crossfades via PfadeIn/PfadeOut) compose
+			// with that function, so ~db must resolve after this event
+			// becomes the parent -- otherwise every fade dies with
+			// "Message 'dbamp' not understood".
+			~db = ~amp.ampdb;
 			~fadeTime = 0.001;
 
 			// values from the clean bus

--- a/classes/CleanEvent.sc
+++ b/classes/CleanEvent.sc
@@ -114,6 +114,7 @@ CleanEvent {
 		var bnd = ~bnd.value;
 		var avgspd, endspd;
 		var useUnit;
+		var fadeOut, fadeIn, totalFade, maxFade;
 
 		~freq = ~freq.value;
 		unitDuration = ~unitDuration.value;
@@ -161,9 +162,25 @@ CleanEvent {
 		// for every buffer, unitDuration is (and should be) defined.
 		~buffer !? { sustain = min(unitDuration, sustain) };
 
-		~fadeTime = min(~fadeTime.value, sustain * 0.19098); // is this number magic?
-		~fadeInTime = if(~bgn != 0) { ~fadeTime } { 0.0 };
-		~sustain = sustain - (~fadeTime + ~fadeInTime);
+		// honor the requested fade times, scaling them down proportionally
+		// if together they exceed the sustain. (an earlier version clamped
+		// fadeTime to sustain * 0.19098 -- the golden section -- which made
+		// long pattern fades silently impossible.) always leave at least
+		// minSustain of body so the event isn't dropped by playSynths.
+		fadeOut = ~fadeTime.value;
+		fadeIn = ~fadeInTime.value ?? { if(~bgn != 0) { fadeOut } { 0.0 } };
+		totalFade = fadeOut + fadeIn;
+		// reserve two minSustains of body: one so playSynths' >= minSustain
+		// check passes, one as margin against float rounding in the
+		// subtraction below.
+		maxFade = max(sustain - (aux.minSustain * 2), 0.0);
+		if(totalFade > maxFade) {
+			fadeOut = fadeOut * maxFade / max(totalFade, 1e-9);
+			fadeIn = fadeIn * maxFade / max(totalFade, 1e-9);
+		};
+		~fadeTime = fadeOut;
+		~fadeInTime = fadeIn;
+		~sustain = sustain - (fadeOut + fadeIn);
 		~spd = spd;
 		~endspd = endspd;
 


### PR DESCRIPTION
Hey Daniel — George here. Three related fixes so fades in patterns actually work:

## 1. `fadeTime` was silently capped at ~19% of sustain

`CleanEvent` clamped it to `sustain * 0.19098` (the golden-section line marked `// is this number magic?`). Asking for `fadeTime: 0.5` with `sustain: 1` sent `0.19098` to `clean_gate`. Long fade-outs were impossible. Requested times are now honored up to the full sustain, scaled down proportionally if they don't fit, always leaving enough body that `playSynths` doesn't drop the event.

## 2. `fadeInTime` couldn't be set explicitly

It only existed as an implicit copy of `fadeTime` when `bgn != 0`. Now `(fadeInTime: 0.3, fadeTime: 0.3, sustain: 1)` does what it says.

## 3. `Pdef(\x).fadeTime` crossfades crashed SuperClean patterns

SC's default parent event defines `\amp` as `#{ ~db.dbamp }`. `PfadeIn`/`PfadeOut` (what Pdef uses to crossfade on `fadeTime`) multiply the event's `\amp` — composing with that function. Since `CleanEvent` replaces the event's parent with the aux's own (which had no `~db`), every crossfade on a pattern without an explicit `\amp` key died mid-fade with `Message 'dbamp' not understood` and the stream stopped. The aux parent event now defines `~db` as the dB mirror of its `~amp`, so those crossfades run to completion.

## Verification

Reproduced and verified against a live server with `s.dumpOSC(1)`:

| Case | Before | After |
|---|---|---|
| `(sustain: 1, fadeTime: 0.5)` | gate got `fadeTime 0.19098` | gate gets `fadeTime 0.5` |
| `(sustain: 1, fadeInTime: 0.3, fadeTime: 0.3)` | fade-in impossible (`bgn == 0`) | `fadeInTime 0.3, fadeTime 0.3, sustain 0.4` |
| `(sustain: 1, fadeInTime: 2, fadeTime: 2)` | clamped | scaled to ~0.5 each, event still plays |
| `Pdef fadeTime` swap, no `\amp` in Pbind | `dbamp not understood`, stream dies | full crossfade |

One thing I deliberately did **not** touch: `~amp = pow(~amp, 1) * ~amp` in `finaliseParameters` squares amp, so amp-based crossfades have a square-law curve (≈6 dB dip mid-crossfade). That's your loudness curve to keep or change — happy to follow up if you want an equal-power option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)